### PR TITLE
Fix how ArraySegment is written into SslStream

### DIFF
--- a/src/Enyim.Caching/Enyim.Caching.csproj
+++ b/src/Enyim.Caching/Enyim.Caching.csproj
@@ -5,7 +5,7 @@
 		<TargetFrameworks>net48;net8.0</TargetFrameworks>
 		<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 		<AssemblyName>EnyimMemcachedRemix</AssemblyName>
-		<PackageVersion>420.0.3</PackageVersion>
+		<PackageVersion>420.0.4</PackageVersion>
 		<PackageId>EnyimMemcachedRemix</PackageId>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageTags>memcached;cache</PackageTags>
@@ -31,7 +31,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MessagePack" Version="2.5.140" />
+		<PackageReference Include="MessagePack" Version="3.1.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Enyim.Caching/Memcached/PooledSocket.cs
+++ b/src/Enyim.Caching/Memcached/PooledSocket.cs
@@ -474,7 +474,7 @@ namespace Enyim.Caching.Memcached
                 {
                     foreach (var buf in buffers)
                     {
-                        _sslStream.Write(buf.Array);
+                        _sslStream.Write(buf.Array, buf.Offset, buf.Count);
                     }
                     _sslStream.Flush();
                 }
@@ -509,7 +509,7 @@ namespace Enyim.Caching.Memcached
                 {
                     foreach (var buf in buffers)
                     {
-                        await _sslStream.WriteAsync(buf.Array, 0, buf.Count);
+                        await _sslStream.WriteAsync(buf.Array, buf.Offset, buf.Count);
                     }
                     await _sslStream.FlushAsync();
                 }


### PR DESCRIPTION
Working with `ArraySegment` requires using Offset and Count properties to correctly address the corresponding segment in the underlying array. This was missing in the code so the `_sslStream.Write(buf.Array)` operation would sometimes send out incorrect data.